### PR TITLE
feat: add subcluster-aware routing with schedule-based failover

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -16,35 +16,70 @@ const booleanFromString = z
   ])
   .transform((val) => val ?? true); // default to true if undefined
 
+// Parse a comma-separated string into a trimmed, non-empty string array
+const commaList = z
+  .string()
+  .optional()
+  .transform((val: string | undefined) =>
+    val
+      ? val
+          .split(",")
+          .map((h: string) => h.trim())
+          .filter(Boolean)
+      : undefined
+  );
+
 // Zod schema for validating configuration
-const ConfigSchema = z.object({
-  host: z.string().min(1, "VERTICA_HOST is required"),
-  port: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .max(65535)
-    .default(DATABASE_CONSTANTS.DEFAULT_PORT),
-  database: z.string().min(1, "VERTICA_DATABASE is required"),
-  user: z.string().min(1, "VERTICA_USER is required"),
-  password: z.string().optional(),
-  connectionLimit: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .max(100)
-    .default(DATABASE_CONSTANTS.DEFAULT_CONNECTION_LIMIT),
-  queryTimeout: z.coerce
-    .number()
-    .int()
-    .min(1000)
-    .max(300000)
-    .default(DATABASE_CONSTANTS.DEFAULT_QUERY_TIMEOUT),
-  ssl: z.coerce.boolean().default(false),
-  sslRejectUnauthorized: z.coerce.boolean().default(true),
-  defaultSchema: z.string().default(DATABASE_CONSTANTS.DEFAULT_SCHEMA),
-  readonlyMode: booleanFromString,
-});
+const ConfigSchema = z
+  .object({
+    host: z.string().optional(),
+    port: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(65535)
+      .default(DATABASE_CONSTANTS.DEFAULT_PORT),
+    database: z.string().min(1, "VERTICA_DATABASE is required"),
+    user: z.string().min(1, "VERTICA_USER is required"),
+    password: z.string().optional(),
+    connectionLimit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .default(DATABASE_CONSTANTS.DEFAULT_CONNECTION_LIMIT),
+    queryTimeout: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(300000)
+      .default(DATABASE_CONSTANTS.DEFAULT_QUERY_TIMEOUT),
+    ssl: z.coerce.boolean().default(false),
+    sslRejectUnauthorized: z.coerce.boolean().default(true),
+    defaultSchema: z.string().default(DATABASE_CONSTANTS.DEFAULT_SCHEMA),
+    readonlyMode: booleanFromString,
+    primaryHosts: commaList,
+    secondaryHosts: commaList,
+    secondarySchedule: z.string().optional().default("MON-FRI 08:00-18:00"),
+    timezone: z.string().optional().default("UTC"),
+  })
+  .superRefine(
+    (
+      data: { host?: string; primaryHosts?: string[] },
+      ctx: z.RefinementCtx
+    ) => {
+      const hasHost = data.host && data.host.length > 0;
+      const hasPrimaryHosts =
+        data.primaryHosts && data.primaryHosts.length > 0;
+      if (!hasHost && !hasPrimaryHosts) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Either VERTICA_HOST or VERTICA_PRIMARY_HOSTS must be set",
+          path: ["host"],
+        });
+      }
+    }
+  );
 
 /**
  * Load and validate Vertica database configuration from environment variables
@@ -62,10 +97,26 @@ export function loadDatabaseConfig(): VerticaConfig {
     sslRejectUnauthorized: process.env.VERTICA_SSL_REJECT_UNAUTHORIZED,
     defaultSchema: process.env.VERTICA_DEFAULT_SCHEMA,
     readonlyMode: process.env.VERTICA_READONLY_MODE,
+    primaryHosts: process.env.VERTICA_PRIMARY_HOSTS,
+    secondaryHosts: process.env.VERTICA_SECONDARY_HOSTS,
+    secondarySchedule: process.env.VERTICA_SECONDARY_SCHEDULE,
+    timezone: process.env.VERTICA_TIMEZONE,
   };
 
   try {
     const validatedConfig = ConfigSchema.parse(rawConfig);
+
+    // Warn about redundant or ineffective configuration
+    if (rawConfig.host && validatedConfig.primaryHosts && validatedConfig.primaryHosts.length > 0) {
+      console.warn(
+        "Warning: VERTICA_HOST is set but ignored — VERTICA_PRIMARY_HOSTS is used for subcluster routing"
+      );
+    }
+    if (rawConfig.secondarySchedule && (!validatedConfig.secondaryHosts || validatedConfig.secondaryHosts.length === 0)) {
+      console.warn(
+        "Warning: VERTICA_SECONDARY_SCHEDULE is set but has no effect — VERTICA_SECONDARY_HOSTS is not configured"
+      );
+    }
 
     // Only log config details in debug mode
     if (process.env.DEBUG === "true" || process.env.VERTICA_DEBUG === "true") {
@@ -92,7 +143,16 @@ export function loadDatabaseConfig(): VerticaConfig {
  * Validate that required environment variables are set
  */
 export function validateRequiredEnvVars(): void {
-  const required = ["VERTICA_HOST", "VERTICA_DATABASE", "VERTICA_USER"];
+  const hasHost = !!process.env.VERTICA_HOST;
+  const hasPrimaryHosts = !!process.env.VERTICA_PRIMARY_HOSTS;
+
+  if (!hasHost && !hasPrimaryHosts) {
+    throw new Error(
+      "Missing required environment variable: either VERTICA_HOST or VERTICA_PRIMARY_HOSTS must be set"
+    );
+  }
+
+  const required = ["VERTICA_DATABASE", "VERTICA_USER"];
   const missing = required.filter((key) => !process.env[key]);
 
   if (missing.length > 0) {

--- a/src/routing/schedule.ts
+++ b/src/routing/schedule.ts
@@ -1,0 +1,119 @@
+export interface SubclusterSchedule {
+  daysOfWeek: number[]; // 0=Sun, 1=Mon, ..., 6=Sat
+  startMinute: number; // minutes since midnight, inclusive (e.g. 480 = 08:00)
+  endMinute: number; // minutes since midnight, exclusive (e.g. 1080 = 18:00)
+  timezone: string; // IANA timezone, e.g. "Europe/Berlin"
+}
+
+const DAY_NAMES: Record<string, number> = {
+  SUN: 0,
+  MON: 1,
+  TUE: 2,
+  WED: 3,
+  THU: 4,
+  FRI: 5,
+  SAT: 6,
+};
+
+/**
+ * Parse a schedule string into a SubclusterSchedule.
+ * Format: "MON-FRI 08:00-18:00"
+ */
+export function parseSchedule(
+  scheduleStr: string,
+  timezone: string
+): SubclusterSchedule {
+  const parts = scheduleStr.trim().split(/\s+/);
+  if (parts.length !== 2) {
+    throw new Error(
+      `Invalid schedule format: "${scheduleStr}". Expected "MON-FRI 08:00-18:00"`
+    );
+  }
+
+  const [dayPart, hourPart] = parts as [string, string];
+
+  // Parse day range
+  let daysOfWeek: number[];
+  if (dayPart.includes("-")) {
+    const [startDayStr, endDayStr] = dayPart.split("-");
+    const startDay = DAY_NAMES[(startDayStr ?? "").toUpperCase()];
+    const endDay = DAY_NAMES[(endDayStr ?? "").toUpperCase()];
+    if (startDay === undefined || endDay === undefined) {
+      throw new Error(
+        `Invalid day names in schedule: "${dayPart}". Use SUN/MON/TUE/WED/THU/FRI/SAT`
+      );
+    }
+    daysOfWeek = [];
+    for (let i = startDay; i <= endDay; i++) daysOfWeek.push(i);
+  } else {
+    const dayIdx = DAY_NAMES[dayPart.toUpperCase()];
+    if (dayIdx === undefined) {
+      throw new Error(
+        `Invalid day name in schedule: "${dayPart}". Use SUN/MON/TUE/WED/THU/FRI/SAT`
+      );
+    }
+    daysOfWeek = [dayIdx];
+  }
+
+  // Parse time range (HH:MM-HH:MM)
+  const [startTimeStr, endTimeStr] = hourPart.split("-");
+  const [startH, startM] = (startTimeStr ?? "").split(":").map(Number);
+  const [endH, endM] = (endTimeStr ?? "").split(":").map(Number);
+
+  if (isNaN(startH!) || isNaN(startM!) || isNaN(endH!) || isNaN(endM!)) {
+    throw new Error(
+      `Invalid time range in schedule: "${hourPart}". Expected "HH:MM-HH:MM"`
+    );
+  }
+
+  return {
+    daysOfWeek,
+    startMinute: startH! * 60 + startM!,
+    endMinute: endH! * 60 + endM!,
+    timezone,
+  };
+}
+
+/**
+ * Check if the current moment falls within the given schedule.
+ * `now` can be injected for testing; defaults to new Date().
+ */
+export function isWithinSchedule(
+  schedule: SubclusterSchedule,
+  now: Date = new Date()
+): boolean {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: schedule.timezone,
+    weekday: "short",
+    hour: "numeric",
+    minute: "numeric",
+    hour12: false,
+  }).formatToParts(now);
+
+  const weekdayStr = parts.find((p) => p.type === "weekday")?.value ?? "";
+  const hourStr = parts.find((p) => p.type === "hour")?.value ?? "0";
+  const minuteStr = parts.find((p) => p.type === "minute")?.value ?? "0";
+
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+
+  const weekday = weekdayMap[weekdayStr];
+  if (weekday === undefined) return false;
+
+  const hour = parseInt(hourStr, 10) % 24; // "24" can appear for midnight in some locales
+  const minute = parseInt(minuteStr, 10);
+  const currentMinute = hour * 60 + minute;
+
+  return (
+    schedule.daysOfWeek.includes(weekday) &&
+    currentMinute >= schedule.startMinute &&
+    currentMinute < schedule.endMinute
+  );
+}

--- a/src/routing/subcluster-router.ts
+++ b/src/routing/subcluster-router.ts
@@ -1,0 +1,127 @@
+import vertica from "vertica-nodejs";
+import { isWithinSchedule, type SubclusterSchedule } from "./schedule.js";
+
+const verticaTyped = vertica as any;
+
+function shuffle<T>(arr: T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j]!, result[i]!];
+  }
+  return result;
+}
+
+export interface SubclusterRouterConfig {
+  primary: { hosts: string[] };
+  secondary: { hosts: string[]; schedule: SubclusterSchedule };
+  port: number;
+  user: string;
+  password?: string;
+  database: string;
+  queryTimeout?: number;
+  ssl?: boolean;
+  sslRejectUnauthorized?: boolean;
+}
+
+export class SubclusterRouter {
+  constructor(private readonly config: SubclusterRouterConfig) {}
+
+  /**
+   * Connect to the appropriate subcluster based on current time.
+   * Within secondary schedule: tries secondary first, falls back to primary if all fail.
+   * Outside secondary schedule: connects directly to primary.
+   * Hosts are shuffled randomly; failed hosts are removed before trying the next.
+   */
+  async connect(): Promise<any> {
+    const secondary = this.config.secondary;
+    const hasSecondary = secondary.hosts.length > 0;
+
+    if (hasSecondary && isWithinSchedule(secondary.schedule)) {
+      const client = await this.trySubcluster(
+        secondary.hosts,
+        "secondary_subcluster"
+      );
+      if (client !== null) return client;
+
+      const primaryClient = await this.trySubcluster(
+        this.config.primary.hosts,
+        "default_subcluster"
+      );
+      if (primaryClient !== null) return primaryClient;
+
+      throw new Error(
+        "Failed to connect to Vertica: all hosts in all subclusters are unreachable"
+      );
+    }
+
+    const client = await this.trySubcluster(
+      this.config.primary.hosts,
+      "default_subcluster"
+    );
+    if (client !== null) return client;
+
+    throw new Error(
+      "Failed to connect to Vertica: all default_subcluster hosts are unreachable"
+    );
+  }
+
+  private async trySubcluster(
+    hosts: string[],
+    subclusterName: string
+  ): Promise<any | null> {
+    const remaining = shuffle(hosts);
+    while (remaining.length > 0) {
+      const host = remaining.shift()!;
+      try {
+        const client = await this.makeClient(host);
+        console.error(
+          `Connected to Vertica subcluster: ${subclusterName} (${host}:${this.config.port}/${this.config.database})`
+        );
+        return client;
+      } catch (err) {
+        console.error(
+          `Failed to connect to ${subclusterName} host ${host}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      }
+    }
+    return null;
+  }
+
+  private async makeClient(host: string): Promise<any> {
+    const cfg = this.config;
+    const clientConfig: Record<string, any> = {
+      host,
+      port: cfg.port,
+      database: cfg.database,
+      user: cfg.user,
+      password: cfg.password,
+      connectionTimeoutMillis: cfg.queryTimeout ?? 30000,
+      ssl: cfg.ssl
+        ? (cfg.sslRejectUnauthorized !== undefined
+            ? cfg.sslRejectUnauthorized
+            : true)
+        : false,
+    };
+    const client = new verticaTyped.Client(clientConfig);
+    await client.connect();
+    return client;
+  }
+}
+
+// Module-level singleton - persists across tool calls within a single MCP process
+let instance: SubclusterRouter | null = null;
+
+export function getRouter(config: SubclusterRouterConfig): SubclusterRouter {
+  if (!instance) {
+    instance = new SubclusterRouter(config);
+  }
+  return instance;
+}
+
+/** Reset the singleton (useful in tests) */
+export function resetRouter(): void {
+  instance = null;
+}

--- a/src/services/vertica-service.ts
+++ b/src/services/vertica-service.ts
@@ -16,6 +16,11 @@ import {
   determineTableType,
   resolveSchemaName,
 } from "../utils/table-helpers.js";
+import {
+  getRouter,
+  type SubclusterRouterConfig,
+} from "../routing/subcluster-router.js";
+import { parseSchedule } from "../routing/schedule.js";
 
 type Connection = any;
 
@@ -43,7 +48,9 @@ export class VerticaService {
   }
 
   /**
-   * Establish connection to Vertica database
+   * Establish connection to Vertica database.
+   * When VERTICA_PRIMARY_HOSTS is set, uses subcluster-aware routing with
+   * time-based selection and automatic failover. Otherwise connects to VERTICA_HOST.
    */
   async connect(): Promise<void> {
     if (this.connection) {
@@ -51,35 +58,32 @@ export class VerticaService {
     }
 
     try {
-      const clientConfig: any = {
-        host: this.config.host,
-        port: this.config.port,
-        database: this.config.database,
-        user: this.config.user,
-        password: this.config.password,
-        connectionTimeoutMillis: this.config.queryTimeout || 30000,
-      };
-
-      // Add SSL/TLS configuration if specified
-      // Note: vertica-nodejs client uses different SSL configuration than the old vertica package
-      if (this.config.ssl) {
-        clientConfig.ssl = true;
-        if (this.config.sslRejectUnauthorized !== undefined) {
-          clientConfig.ssl = this.config.sslRejectUnauthorized;
-        }
+      if (this.config.primaryHosts && this.config.primaryHosts.length > 0) {
+        const routerConfig = this.buildRouterConfig();
+        this.connection = await getRouter(routerConfig).connect();
       } else {
-        // Explicitly disable SSL/TLS for vertica-nodejs client
-        clientConfig.ssl = false;
+        const clientConfig: Record<string, unknown> = {
+          host: this.config.host,
+          port: this.config.port,
+          database: this.config.database,
+          user: this.config.user,
+          password: this.config.password,
+          connectionTimeoutMillis: this.config.queryTimeout ?? 30000,
+          ssl: this.config.ssl
+            ? (this.config.sslRejectUnauthorized !== undefined
+                ? this.config.sslRejectUnauthorized
+                : true)
+            : false,
+        };
+
+        const client = new verticaTyped.Client(clientConfig);
+        await client.connect();
+        this.connection = client;
+
+        console.error(
+          `${LOG_MESSAGES.DB_CONNECTED}: ${this.config.host}:${this.config.port}/${this.config.database}`
+        );
       }
-
-      const client = new verticaTyped.Client(clientConfig);
-
-      await client.connect();
-      this.connection = client;
-
-      console.error(
-        `${LOG_MESSAGES.DB_CONNECTED}: ${this.config.host}:${this.config.port}/${this.config.database}`
-      );
     } catch (error) {
       throw new Error(
         `Failed to connect to Vertica: ${
@@ -87,6 +91,28 @@ export class VerticaService {
         }`
       );
     }
+  }
+
+  private buildRouterConfig(): SubclusterRouterConfig {
+    const cfg = this.config;
+    const schedule = parseSchedule(
+      cfg.secondarySchedule ?? "MON-FRI 08:00-18:00",
+      cfg.timezone ?? "UTC"
+    );
+    return {
+      primary: { hosts: cfg.primaryHosts! },
+      secondary: {
+        hosts: cfg.secondaryHosts ?? [],
+        schedule,
+      },
+      port: cfg.port,
+      user: cfg.user,
+      password: cfg.password,
+      database: cfg.database,
+      queryTimeout: cfg.queryTimeout,
+      ssl: cfg.ssl,
+      sslRejectUnauthorized: cfg.sslRejectUnauthorized,
+    };
   }
 
   /**

--- a/src/types/vertica.ts
+++ b/src/types/vertica.ts
@@ -1,5 +1,5 @@
 export interface VerticaConfig {
-  host: string;
+  host?: string;
   port: number;
   database: string;
   user: string;
@@ -10,6 +10,12 @@ export interface VerticaConfig {
   sslRejectUnauthorized?: boolean;
   defaultSchema?: string;
   readonlyMode?: boolean;
+  // Sub-cluster host lists
+  primaryHosts?: string[];
+  secondaryHosts?: string[];
+  // Secondary sub-cluster scheduling
+  secondarySchedule?: string;
+  timezone?: string;
 }
 
 export interface QueryResult {


### PR DESCRIPTION
vertica-nodejs does not support the connectionLoadBalance parameter available in JDBC/ODBC drivers. Implements similar behavior via time-based routing between primary and secondary Vertica subclusters, with shuffled host selection and per-attempt failover